### PR TITLE
Fix the go.mod to match the repository name

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/rpcpool/tpu-traffic-classes
+module github.com/rpcpool/tpu-traffic-classifier
 
 go 1.22.0
 


### PR DESCRIPTION
By default, `go build .` will build a binary with the name from the go mod. In this case, it builds a binary with the name `tpu-traffic-classes`. This fixes it to match the name of the repository.