### PR TITLE
Add custom node management

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ It also uses the PREROUTING tables to permanently mark traffic from these sets o
  - `3`: staked
  - `5`: min staked > 15K
  - `9`: high staked > 150K
+ - `11`: custom nodes
 
 If you provide you validator pubkey it will assume that your validator runs on localhost and it will lookup the TPU port of the validator and enable the firewalling rules. If you do not provide your validator pubkey, all UDP traffic passing through this host will be passed through the chains created by this tool.
 

--- a/config.yml
+++ b/config.yml
@@ -14,3 +14,14 @@ staked_classes:
   - name: solana-high-staked
     stake_percentage: 0.0003
     fwmark: 9
+
+# Custom nodes class, i.e. an allowlist for nodes not in gossip
+custom_node_class:
+  name: custom-nodes
+  fwmark: 11
+
+custom_node_entries:
+  - name: my_rpc_node
+    ip: 1.2.3.4
+  - name: my_other_node
+    ip: 4.5.6.7

--- a/validator-ports.go
+++ b/validator-ports.go
@@ -3,17 +3,16 @@ package main
 import "strconv"
 
 type ValidatorPorts struct {
-	TPU     uint16
-	TPUfwd  uint16
-	TPUvote uint16
-	TPUquic	uint16
-	TPUquicfwd	uint16
+	TPU        uint16
+	TPUfwd     uint16
+	TPUvote    uint16
+	TPUquic    uint16
+	TPUquicfwd uint16
 }
 
 func (vp *ValidatorPorts) TPUstr() string {
 	return strconv.FormatUint(uint64(vp.TPU), 10)
 }
-
 
 func (vp *ValidatorPorts) TPUquicstr() string {
 	return strconv.FormatUint(uint64(vp.TPUquic), 10)
@@ -22,7 +21,6 @@ func (vp *ValidatorPorts) TPUquicstr() string {
 func (vp *ValidatorPorts) Fwdstr() string {
 	return strconv.FormatUint(uint64(vp.TPUfwd), 10)
 }
-
 
 func (vp *ValidatorPorts) TPUquicfwdstr() string {
 	return strconv.FormatUint(uint64(vp.TPUquicfwd), 10)
@@ -34,10 +32,10 @@ func (vp *ValidatorPorts) Votestr() string {
 
 func NewValidatorPorts(tpu uint16, tpu_quic uint16) *ValidatorPorts {
 	return &ValidatorPorts{
-		TPU:     tpu,
-		TPUfwd:  tpu + 1,
-		TPUvote: tpu + 2,
-		TPUquic: tpu_quic,
-		TPUquicfwd: tpu_quic+1,
+		TPU:        tpu,
+		TPUfwd:     tpu + 1,
+		TPUvote:    tpu + 2,
+		TPUquic:    tpu_quic,
+		TPUquicfwd: tpu_quic + 1,
 	}
 }


### PR DESCRIPTION
This adds config support, and custom node class management for the TPU Traffic Classifier.  This should allow validator operators to use the same set of tools to manage gossip, and non-gossip sources.